### PR TITLE
Updated go-ossf-slsa3-publish.yml to extract REPO_NAME and use it in …

### DIFF
--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -24,6 +24,9 @@ jobs:
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.3.4
         with:
           fetch-depth: 0
+      - id: extract_repo_name
+        run: |
+          echo "REPO_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_ENV
       - id: ldflags
         run: |
           echo "commit-date=$(git log --date=iso8601-strict -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"

--- a/.slsa-goreleaser/linux-amd64.yml
+++ b/.slsa-goreleaser/linux-amd64.yml
@@ -26,7 +26,7 @@ goarch: amd64
 # Binary output name.
 # {{ .Os }} will be replaced by goos field in the config file.
 # {{ .Arch }} will be replaced by goarch field in the config file.
-binary: test-{{ .Os }}-{{ .Arch }}
+binary: ${{ env.REPO_NAME }}-{{ .Os }}-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:


### PR DESCRIPTION
….slsa-goreleaser/linux-amd64.yml as a templated part of binary name